### PR TITLE
after-order-create

### DIFF
--- a/httpdocs/includes/modules/payment/cardstream.php
+++ b/httpdocs/includes/modules/payment/cardstream.php
@@ -440,6 +440,10 @@ HTML;
 
         $successUrl = zen_href_link(FILENAME_CHECKOUT_SUCCESS, '', 'SSL', true, false);
 
+        if (MODULE_PAYMENT_CARDSTREAM_CAPTURE_TYPE == 'Hosted') {
+           return;
+        }
+
         if (MODULE_PAYMENT_CARDSTREAM_CAPTURE_TYPE == 'Direct V2') {
             echo <<<HTML
 Processing secure form, please wait ...


### PR DESCRIPTION
We are using the 'hosted' Cardstream gateway with Zen Cart. Payments were being made but the orders were not being specified and no e-mail confirmations from Zen Cart were sent. The cardstream after-order-order function was not returning after being called by the Zen Cart checkout_process.php. We have added a RETURN when MODULE_PAYMENT_CARDSTREAM_CAPTURE_TYPE == 'Hosted'. Everything is now working and the 'hosted' gateway is now live.

Best regards,
Mike Robotham